### PR TITLE
lxd: update LXD images: remote

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: spread-mir-ci
-base: core20
+base: core22
 version: git
 summary: Convenient full-system test (task) distribution
 description: |
@@ -30,4 +30,6 @@ parts:
         - bin/lxc
     spread:
         plugin: go
+        build-snaps:
+        - go
         source: .

--- a/spread/lxd.go
+++ b/spread/lxd.go
@@ -351,7 +351,7 @@ var errNoImage = fmt.Errorf("image not found")
 
 var lxdRemoteServer = map[string]string{
 	"ubuntu": "https://cloud-images.ubuntu.com/releases",
-	"images": "https://images.linuxcontainers.org",
+	"images": "https://images.lxd.canonical.com",
 }
 
 func (p *lxdProvider) lxdRemoteNames() (map[string]string, error) {


### PR DESCRIPTION
Ref. https://discourse.ubuntu.com/t/new-lxd-image-server-available-images-lxd-canonical-com/43824

Validated here: https://github.com/canonical/mir/pull/3341